### PR TITLE
Add link to cookiecutter-raml template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -719,8 +719,12 @@ Other
 ~~~~~
 
 * `cookiecutter_dotfile`_: Template for a folder of dotfiles managed by stow.
+* `cookiecutter-raml`_: Template for RAML v1.0 API documents.
+
 
 .. _`cookiecutter_dotfile`: https://github.com/bdcaf/cookiecutter_dotfile
+.. _`cookiecutter-raml`: https://github.com/genzj/cookiecutter-raml
+
 
 Similar projects
 ----------------


### PR DESCRIPTION
I created a template for [RAML](https://raml.org/) documents creation. Hope it's helpful.